### PR TITLE
Fix: Clerk sign-in via OAuth browser flow (Expo)

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -6,6 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
+    "scheme": "novi",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/frontend/app/(auth)/register.tsx
+++ b/frontend/app/(auth)/register.tsx
@@ -3,29 +3,30 @@ import { View, StyleSheet, Alert } from 'react-native';
 import { TextInput, Button, Text, Card, Title } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { useSignUp } from '@clerk/clerk-expo';
+import { useSignUp, useOAuth } from '@clerk/clerk-expo';
+import * as Linking from 'expo-linking';
 import { theme } from '../../theme/theme';
 
 export default function RegisterScreen() {
   const { signUp, setActive, isLoaded } = useSignUp();
+  const { startOAuthFlow } = useOAuth({ strategy: 'oauth_google' });
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(false);
+
   const handleRegister = async () => {
     if (!isLoaded) return;
 
     setLoading(true);
     try {
-      // Create the user account (no verification needed)
       const result = await signUp.create({
         emailAddress: email,
         password,
         firstName: name,
       });
 
-      // If account creation is complete, sign in immediately
       if (result.status === 'complete') {
         await setActive({ session: result.createdSessionId });
         router.replace('/(tabs)');
@@ -37,56 +38,22 @@ export default function RegisterScreen() {
     }
   };
 
-  // COMMENTED OUT: Email verification flow (disabled in Clerk dashboard)
-  /*
-  if (verifying) {
-    return (
-      <SafeAreaView style={styles.container}>
-        <View style={styles.content}>
-          <Card style={styles.card}>
-            <Card.Content>
-              <Title style={styles.title}>Verify Your Email</Title>
-              <Text style={styles.subtitle}>
-                We sent a verification code to {email}
-              </Text>
+  const handleGoogleRegister = async () => {
+    setLoading(true);
+    try {
+      const redirectUrl = Linking.createURL('/');
+      const { createdSessionId, setActive: setActiveFromOAuth } = await startOAuthFlow({ redirectUrl });
+      if (createdSessionId) {
+        await setActiveFromOAuth({ session: createdSessionId });
+        router.replace('/(tabs)');
+      }
+    } catch (err: any) {
+      Alert.alert('Error', err.errors?.[0]?.message || 'Google sign-in failed');
+    } finally {
+      setLoading(false);
+    }
+  };
 
-              <TextInput
-                label="Verification Code"
-                value={code}
-                onChangeText={setCode}
-                mode="outlined"
-                style={styles.input}
-                keyboardType="number-pad"
-                autoCapitalize="none"
-                placeholder="Enter 6-digit code"
-              />
-
-              <Button
-                mode="contained"
-                onPress={handleVerify}
-                loading={loading}
-                disabled={!code || loading}
-                style={styles.button}
-              >
-                Verify Email
-              </Button>
-
-              <Button
-                mode="text"
-                onPress={() => setVerifying(false)}
-                style={styles.linkButton}
-              >
-                Back to registration
-              </Button>
-            </Card.Content>
-          </Card>
-        </View>
-      </SafeAreaView>
-    );
-  }
-  */
-
-  // Display initial registration form
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
@@ -94,6 +61,15 @@ export default function RegisterScreen() {
           <Card.Content>
             <Title style={styles.title}>Create Account</Title>
             <Text style={styles.subtitle}>Sign up to get started</Text>
+
+            <Button
+              mode="contained"
+              onPress={handleGoogleRegister}
+              loading={loading}
+              style={styles.button}
+            >
+              Continue with Google
+            </Button>
 
             <TextInput
               label="Name"
@@ -123,19 +99,14 @@ export default function RegisterScreen() {
               secureTextEntry
             />
 
-            {/* Clerk CAPTCHA widget */}
-            {/* <View style={styles.captchaContainer}>
-              <div id="clerk-captcha" />
-            </View> */}
-
             <Button
-              mode="contained"
+              mode="outlined"
               onPress={handleRegister}
               loading={loading}
               disabled={!email || !password || !name || loading}
               style={styles.button}
             >
-              Sign Up
+              Sign Up with Email
             </Button>
 
             <Button

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -5,16 +5,18 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ClerkProvider } from '@clerk/clerk-expo';
 import { tokenCache } from '@clerk/clerk-expo/token-cache'
+import * as WebBrowser from 'expo-web-browser';
 
 import { clerkConfig } from '../config/clerk';
 import { theme } from '../theme/theme';
 
-// Create a client for React Query
+WebBrowser.maybeCompleteAuthSession();
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 2,
-      staleTime: 5 * 60 * 1000, // 5 minutes
+      staleTime: 5 * 60 * 1000,
     },
   },
 });


### PR DESCRIPTION
Fix Clerk sign-in on Expo by using OAuth via the in-app browser and configuring an app linking scheme. This avoids the CAPTCHA requirement on password flows without changing the tech stack.

Changes
- Add WebBrowser.maybeCompleteAuthSession() in app root
- Add Google OAuth button on Login and Register screens using startOAuthFlow()
- Configure Expo app.json with a scheme for redirect handling
- Keep existing email/password UI as secondary option

Nature
- Enhancement to existing sign-in flow; no stack changes

Impact
- Users can successfully authenticate in dev/prod without reCAPTCHA setup
- Minimal code changes, preserves current routing and UI components

Why
- Clerk password flows require CAPTCHA; opening a browser OAuth flow resolves this quickly and reliably for now.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/1f9d19c1-bfa2-434c-8dc7-af61b6460e95/task/3f85c39a-8350-40f4-8420-88a0446ca789))